### PR TITLE
Change return message upon success

### DIFF
--- a/src/update.php
+++ b/src/update.php
@@ -261,7 +261,7 @@ NSUPDATE;
 
     if ($ret === 0) {
 
-        echo 'success';
+        echo 'good';
 
     } else {
 


### PR DESCRIPTION
This changes the return message from `success` to `good` in case of a successful DNS update. This is in line with the API provided by public DNS providers and fixes issues with clients expecting this message.

Fixes issue #2.